### PR TITLE
Allow raster bands in Collection's item assets

### DIFF
--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -47,6 +47,12 @@
               "additionalProperties": {
                 "$ref": "#/definitions/assetfields"
               }
+            },
+            "item_assets": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/assetfields"
+              }
             }
           }
         }


### PR DESCRIPTION
This PR modifies the JSON Schema to allow raster band information in a Collection's `item_assets` key. This is identical to what the EO extension does: https://github.com/stac-extensions/eo/blob/89da8dc305f43cf34980b3d52f3bfbbc4d8c88d4/json-schema/schema.json#L85-L96