### PR TITLE
Update to use STAC 1.1 bands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -8,18 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add link `rel="gcps"` to Ground Control Points document
-- All raster fields can now be used in the new bands field in STAC 1.1
+- Add link relation type `gcps` for Ground Control Points documents
+- `raster:sampling`, `raster:bits_per_sample`, `raster:spatial_resolution`, `raster:scale`, `raster:offset` and `raster:histogram`
+  can be used in Assets and Item Properties
 
 ### Changed
 
 - Some clarifications and fixes in the README and examples [#41](https://github.com/stac-extensions/raster/pull/41)
-- `raster:bands` is now using the more general `bands` field from STAC 1.1 common metadata
-- All of the fields in the `raster:bands` object have been renamed to have a prefix of `raster:`
+- `raster:bands` is now using the more general `bands` construct from STAC common metadata
+- The following fields in the Band Object have been moved/renamed:
+  - `nodata`, `data_type`, `statistics` and `unit` were *not* renamed, but have been moved to STAC common metadata
+  - `sampling` has been renamed to `raster:sampling`
+  - `bits_per_sample` has been renamed to `raster:bits_per_sample`
+  - `spatial_resolution` has been renamed to `raster:spatial_resolution`
+  - `scale` has been renamed to `raster:scale`
+  - `offset` has been renamed to `raster:offset`
+  - `histogram` has been renamed to `raster:histogram`
 
 ### Removed
 
-- `raster:bands` - use `bands` in STAC core instead
+- `raster:bands` - use `bands` in instead
 
 ## [v1.1.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,17 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Some clarifications and fixes in the README and examples [#41](https://github.com/stac-extensions/raster/pull/41)
 - `raster:bands` is now using the more general `bands` field from STAC 1.1 common metadata
-- The following fields in the `raster:bands` object have been moved/renamed:
-   - nodata -> raster:nodata
-   - sampling -> raster:sampling
-   - data_type -> raster:data_type
-   - bits_per_sample -> raster:bits_per_sample
-   - spatial_resolution -> raster:spatial_resolution
-   - statistics -> raster:statistics
-   - unit -> raster:unit
-   - scale -> raster:scale
-   - offset -> raster:offset
-   - histogram -> raster:histogram
+- All of the fields in the `raster:bands` object have been renamed to have a prefix of `raster:`
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add link `rel="gcps"` to Ground Control Points document
+- All raster fields can now be used in the new bands field in STAC 1.1
 
 ### Changed
 
-- Some clarifications abd fixes in the README and examples [#41](https://github.com/stac-extensions/raster/pull/41)
+- Some clarifications and fixes in the README and examples [#41](https://github.com/stac-extensions/raster/pull/41)
+- `raster:bands` is now using the more general `bands` field from STAC 1.1 common metadata
+- The following fields in the `raster:bands` object have been moved/renamed:
+   - nodata -> raster:nodata
+   - sampling -> raster:sampling
+   - data_type -> raster:data_type
+   - bits_per_sample -> raster:bits_per_sample
+   - spatial_resolution -> raster:spatial_resolution
+   - statistics -> raster:statistics
+   - unit -> raster:unit
+   - scale -> raster:scale
+   - offset -> raster:offset
+   - histogram -> raster:histogram
+
+### Removed
+
+- `raster:bands` - use `bands` in STAC core instead
 
 ## [v1.1.0]
 

--- a/README.md
+++ b/README.md
@@ -91,44 +91,27 @@ The allowed values for `data_type` are:
 | stddev        | number | standard deviation value of the pixels in the band |
 | valid_percent | number | percentage of valid (not `nodata`) pixel           |
 
-### Scale and Offset Uses and Examples
+### Use Scale and offset as radiometric calibration parameters
 
-In remote sensing, most imagery raster corresponds to just unitless raw pixel values that may be converted
-into specific units given a scale and an offset. The raw pixel values are referred to as 
-Digital Numbers (DN). Using a Scale and Offset simply provide a more efficient
-way to store data with less bytes. In these cases the data provider will include scale and offset
-values for transforming the data into a physical measurement, such as radiance, power, altitude, or
-backscatter. Several examples are given below.
+In remote sensing, many imagery raster corresponds to raw data without any radiometric processing.
+Each pixel is given in digital numbers (DN), i.e. native pixel values from the sensor acquisition.
+Those digital numbers quantify the energy recorded by the detector (optical or radar).
+The sensor radiometric calibration aims to turn back the DN value into a
+physical unit value (radiance, light power, backscatter).
+Hereafter, some examples of the usage of the `values` dictionary to perform radiometric correction.
 
-Users should be careful to always apply any provided scale and offset
+#### Digital Numbers to Radiance (optical sensor)
 
-#### DN to Reflectance
+<!-- https://labo.obs-mip.fr/multitemp/radiometric-quantities-irradiance-radiance-reflectance/ -->
 
-A very common use case is to store reflectance values, which range from 0 - 1.0, as integers rather than
-utilizing the larger floating point data type. Data is stored in a 2-byte Integer and ranges from
-1 to 10,0000 by using a scale of 0.0001, resulting in a file half the size of one using 4 by te floats.
-
-```json
-"assets": {
-  "B4": {
-      "title": "TOA radiance band 4",
-      "bands": [{
-        "raster:nodata": 0,
-        "raster:scale": 0.0001,
-        "raster:offset": 0.0
-      }]
-  }
-}
-```
-
-#### Digital Numbers to Optical Radiance
-
-A conventional way of deriving Top Of Atmosphere (TOA) Radiance in $ W.sr^{-1}.m^{-3}\ $
+A conventional way of deriving Top Of Atmosphere (TOA) Radiance
+in ![formula](https://render.githubusercontent.com/render/math?math=W.sr^{-1}.m^{-3})
 from DN values using `scale` and `offset` in the following formula:
 
-$$ L_\lambda=scale\times DN + offset $$
+![formula](https://render.githubusercontent.com/render/math?math=\color{gray}L_\lambda%20=%20scale%20\times%20DN%20%2B%20offset)
 
-where $ L_\lambda $ is TOA Radiance with units of $ W.sr^{-1}.m^{-3} $.
+where ![formula](https://render.githubusercontent.com/render/math?math=\color{gray}L_\lambda) is TOA Radiance
+in ![formula](https://render.githubusercontent.com/render/math?math=\color{gray}W.sr^{-1}.m^{-3}).
 
 For example, the above value conversion is described in the values dictionary as
 
@@ -146,22 +129,22 @@ For example, the above value conversion is described in the values dictionary as
 }
 ```
 
-##### Radiance to TOA Optical Reflectance
+#### Radiance to TOA Reflectance (optical sensor)
 
 In order to convert the above TOA radiance to TOA reflectance, the following formula can be used:
 
-$$ R=(pi*L*d*d)/(ESUN*cos(s)) $$
+![formula](https://render.githubusercontent.com/render/math?math=\color{gray}R=(pi*L*d*d)/(ESUN*cos(s)))
 
 where:
 
 - L is the spectral radiance for the band (see previous section)
-- d is the earth-sun distance (in astronomical units) and depends on the acquisition’s day and month
-- ESUN is the mean TOA solar irradiance (or [solar illumination](https://github.com/stac-extensions/eo#solar_illumination)) in W/m2/micrometers
+- d is the earth-sun distance (in astronomical units) and depends on the acquisition’s day and month ([Core STAC specification](https://github.com/radiantearth/stac-spec/blob/master/item-spec/item-spec.md#properties-object))
+- ESUN(b) is the mean TOA solar irradiance (or [solar illumination](https://github.com/stac-extensions/eo#solar_illumination)) in W/m2/micrometers
 - s is the [solar zenith angle](https://github.com/stac-extensions/view#item-properties) in degrees.
 
 source: <https://www.orfeo-toolbox.org/CookBook/Applications/app_OpticalCalibration.html>
 
-#### Altitude to water level
+#### Transform height measurement to water level
 
 In remote sensing, radar altimeter instruments measures an absolute height from an absolute georeference (e.g. WGS 84 geoid).
 In hydrology, you prefer having the water level relative to the "0 limnimetric scale".

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 This document explains the Raster Extension to the [SpatioTemporal Asset Catalog](https://github.com/radiantearth/stac-spec) (STAC) specification.
 
 An item can describe assets that are rasters of one or multiple bands with some information common to them all (raster size, projection)
-and also specific to each of them (data type, unit, number of bits used, nodata).
+and also specific to each of them (number of bits used).
 A raster is often strongly linked with the georeferencing transform and coordinate system definition
 of all bands (using the [projection extension](https://github.com/radiantearth/stac-spec/tree/master/extensions/projection)).
 In many applications, it is interesting to have some metadata about the rasters in the asset (values statistics, value interpretation, transforms).
@@ -38,58 +38,14 @@ to specify information about the raster projection, especially `proj:shape` to s
 
 | Field Name         | Type                                    | Description                                                                                                                                                                       |
 | ------------------ | --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| raster:nodata             | number\|string                          | Pixel values used to identify pixels that are nodata in the band either by the pixel value as a number or `nan`, `inf` or `-inf` (all strings).                                   |
 | raster:sampling           | string                                  | One of `area` or `point`. Indicates whether a pixel value should be assumed to represent a sampling over the region of the pixel or a point sample at the center of the pixel.    |
-| raster:data_type          | string                                  | The data type of the pixels in the band. One of the [data types as described below](#data-types).                                                                                 |
 | raster:bits_per_sample    | number                                  | The actual number of bits used for this band. Normally only present when the number of bits is non-standard for the `datatype`, such as when a 1 bit TIFF is represented as byte. |
 | raster:spatial_resolution | number                                  | Average spatial resolution (in meters) of the pixels in the band.                                                                                                                 |
-| raster:statistics         | [Statistics Object](#statistics-object) | Statistics of all the pixels in the band.                                                                                                                                         |
-| raster:unit               | string                                  | Unit denomination of the pixel value.                                                                                                                                             |
 | raster:scale              | number                                  | Multiplicator factor of the pixel value to transform into the value (i.e. translate digital number to reflectance).                                                               |
 | raster:offset             | number                                  | Number to be added to the pixel value (after scaling) to transform into the value (i.e. translate digital number to reflectance).                                                 |
 | raster:histogram          | [Histogram Object](#histogram-object)   | Histogram distribution information of the pixels values in the band.                                                                                                              |
 
 `raster:scale` and `raster:offset` define parameters to compute another value. The following paragraphs describe some use cases.
-
-### Data Types
-
-The data type gives information about the values in the file.
-This can be used to indicate the (maximum) range of numerical values expected.
-For example `uint8` indicates that the numbers are in a range between 0 and 255,
-they can never be smaller or larger. This can help to pick the optimal numerical
-data type when reading the files to keep memory consumption low.
-Nevertheless, it doesn't necessarily mean that the expected values fill the whole range.
-For example, there can be use cases for `uint8` that just use the numbers 0 to 10 for example.
-Through other extensions it might be possible to specify an exact value range so
-that visualizations can be optimized.
-The allowed values for `data_type` are:
-
-- `int8`: 8-bit integer
-- `int16`: 16-bit integer
-- `int32`: 32-bit integer
-- `int64`: 64-bit integer
-- `uint8`: unsigned 8-bit integer (common for 8-bit RGB PNG's)
-- `uint16`: unsigned 16-bit integer
-- `uint32`: unsigned 32-bit integer
-- `uint64`: unsigned 64-bit integer
-- `float16`: 16-bit float
-- `float32`: 32-bit float
-- `float64`: 64-big float
-- `cint16`: 16-bit complex integer
-- `cint32`: 32-bit complex integer
-- `cfloat32`: 32-bit complex float
-- `cfloat64`: 64-bit complex float
-- `other`: Other data type than the ones listed above (e.g. boolean, string, higher precision numbers)
-
-### Statistics Object
-
-| Field Name    | Type   | Description                                        |
-| ------------- | ------ | -------------------------------------------------- |
-| mean          | number | mean value of all the pixels in the band           |
-| minimum       | number | minimum value of the pixels in the band            |
-| maximum       | number | maximum value of the pixels in the band            |
-| stddev        | number | standard deviation value of the pixels in the band |
-| valid_percent | number | percentage of valid (not `nodata`) pixel           |
 
 ### Use Scale and offset as radiometric calibration parameters
 
@@ -120,8 +76,8 @@ For example, the above value conversion is described in the values dictionary as
   "B4": {
       "title": "TOA radiance band 4",
       "bands": [{
-        "raster:nodata": 0,
-        "raster:unit": "W⋅sr−1⋅m−2",
+        "nodata": 0,
+        "unit": "W⋅sr−1⋅m−2",
         "raster:scale": 0.0145,
         "raster:offset": 3.48
       }]
@@ -158,7 +114,7 @@ In the following value definition example, 185 meters must be substracted from t
   "WaterLevel": {
       "title": "Water Level at station",
       "bands": [{
-        "raster:unit": "m",
+        "unit": "m",
         "raster:offset": -185
       }]
   }

--- a/README.md
+++ b/README.md
@@ -91,27 +91,44 @@ The allowed values for `data_type` are:
 | stddev        | number | standard deviation value of the pixels in the band |
 | valid_percent | number | percentage of valid (not `nodata`) pixel           |
 
-### Use Scale and offset as radiometric calibration parameters
+### Scale and Offset Uses and Examples
 
-In remote sensing, many imagery raster corresponds to raw data without any radiometric processing.
-Each pixel is given in digital numbers (DN), i.e. native pixel values from the sensor acquisition.
-Those digital numbers quantify the energy recorded by the detector (optical or radar).
-The sensor radiometric calibration aims to turn back the DN value into a
-physical unit value (radiance, light power, backscatter).
-Hereafter, some examples of the usage of the `values` dictionary to perform radiometric correction.
+In remote sensing, most imagery raster corresponds to just unitless raw pixel values that may be converted
+into specific units given a scale and an offset. The raw pixel values are referred to as 
+Digital Numbers (DN). Using a Scale and Offset simply provide a more efficient
+way to store data with less bytes. In these cases the data provider will include scale and offset
+values for transforming the data into a physical measurement, such as radiance, power, altitude, or
+backscatter. Several examples are given below.
 
-#### Digital Numbers to Radiance (optical sensor)
+Users should be careful to always apply any provided scale and offset
 
-<!-- https://labo.obs-mip.fr/multitemp/radiometric-quantities-irradiance-radiance-reflectance/ -->
+#### DN to Reflectance
 
-A conventional way of deriving Top Of Atmosphere (TOA) Radiance
-in ![formula](https://render.githubusercontent.com/render/math?math=W.sr^{-1}.m^{-3})
+A very common use case is to store reflectance values, which range from 0 - 1.0, as integers rather than
+utilizing the larger floating point data type. Data is stored in a 2-byte Integer and ranges from
+1 to 10,0000 by using a scale of 0.0001, resulting in a file half the size of one using 4 by te floats.
+
+```json
+"assets": {
+  "B4": {
+      "title": "TOA radiance band 4",
+      "bands": [{
+        "raster:nodata": 0,
+        "raster:scale": 0.0001,
+        "raster:offset": 0.0
+      }]
+  }
+}
+```
+
+#### Digital Numbers to Optical Radiance
+
+A conventional way of deriving Top Of Atmosphere (TOA) Radiance in $ W.sr^{-1}.m^{-3}\ $
 from DN values using `scale` and `offset` in the following formula:
 
-![formula](https://render.githubusercontent.com/render/math?math=\color{gray}L_\lambda%20=%20scale%20\times%20DN%20%2B%20offset)
+$$ L_\lambda=scale\times DN + offset $$
 
-where ![formula](https://render.githubusercontent.com/render/math?math=\color{gray}L_\lambda) is TOA Radiance
-in ![formula](https://render.githubusercontent.com/render/math?math=\color{gray}W.sr^{-1}.m^{-3}).
+where $ L_\lambda $ is TOA Radiance with units of $ W.sr^{-1}.m^{-3} $.
 
 For example, the above value conversion is described in the values dictionary as
 
@@ -129,22 +146,22 @@ For example, the above value conversion is described in the values dictionary as
 }
 ```
 
-#### Radiance to TOA Reflectance (optical sensor)
+##### Radiance to TOA Optical Reflectance
 
 In order to convert the above TOA radiance to TOA reflectance, the following formula can be used:
 
-![formula](https://render.githubusercontent.com/render/math?math=\color{gray}R=(pi*L*d*d)/(ESUN*cos(s)))
+$$ R=(pi*L*d*d)/(ESUN*cos(s)) $$
 
 where:
 
 - L is the spectral radiance for the band (see previous section)
-- d is the earth-sun distance (in astronomical units) and depends on the acquisition’s day and month ([Core STAC specification](https://github.com/radiantearth/stac-spec/blob/master/item-spec/item-spec.md#properties-object))
-- ESUN(b) is the mean TOA solar irradiance (or [solar illumination](https://github.com/stac-extensions/eo#solar_illumination)) in W/m2/micrometers
+- d is the earth-sun distance (in astronomical units) and depends on the acquisition’s day and month
+- ESUN is the mean TOA solar irradiance (or [solar illumination](https://github.com/stac-extensions/eo#solar_illumination)) in W/m2/micrometers
 - s is the [solar zenith angle](https://github.com/stac-extensions/view#item-properties) in degrees.
 
 source: <https://www.orfeo-toolbox.org/CookBook/Applications/app_OpticalCalibration.html>
 
-#### Transform height measurement to water level
+#### Altitude to water level
 
 In remote sensing, radar altimeter instruments measures an absolute height from an absolute georeference (e.g. WGS 84 geoid).
 In hydrology, you prefer having the water level relative to the "0 limnimetric scale".

--- a/README.md
+++ b/README.md
@@ -21,32 +21,35 @@ In many applications, it is interesting to have some metadata about the rasters 
 - [JSON Schema](json-schema/schema.json)
 - [Changelog](./CHANGELOG.md)
 
-## Item Asset fields
+## Fields
 
-| Field Name   | Type                                         | Description                                                                                                                     |
-| ------------ | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| raster:bands | \[[Raster band Object](#raster-band-object)] | An array of available bands where each object is a \[[Band Object](#raster-band-object)]. If given, requires at least one band. |
+The fields in the table below can be used in these parts of STAC documents:
 
-## Raster Band Object
+- [ ] Catalogs
+- [ ] Collections
+- [x] Item Properties (incl. Summaries in Collections)
+- [x] Assets (for both Collections and Items, incl. Item Asset Definitions in Collections)
+- [x] Bands
+- [ ] Links
 
-When specifying a raster band object at asset level, it is recommended to use
+When using the raster extension, it is recommended to use
 the [projection](https://github.com/radiantearth/stac-spec/tree/master/extensions/projection) extension
 to specify information about the raster projection, especially `proj:shape` to specify the height and width of the raster.
 
 | Field Name         | Type                                    | Description                                                                                                                                                                       |
 | ------------------ | --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| nodata             | number\|string                          | Pixel values used to identify pixels that are nodata in the band either by the pixel value as a number or `nan`, `inf` or `-inf` (all strings).                                   |
-| sampling           | string                                  | One of `area` or `point`. Indicates whether a pixel value should be assumed to represent a sampling over the region of the pixel or a point sample at the center of the pixel.    |
-| data_type          | string                                  | The data type of the pixels in the band. One of the [data types as described below](#data-types).                                                                                 |
-| bits_per_sample    | number                                  | The actual number of bits used for this band. Normally only present when the number of bits is non-standard for the `datatype`, such as when a 1 bit TIFF is represented as byte. |
-| spatial_resolution | number                                  | Average spatial resolution (in meters) of the pixels in the band.                                                                                                                 |
-| statistics         | [Statistics Object](#statistics-object) | Statistics of all the pixels in the band.                                                                                                                                         |
-| unit               | string                                  | Unit denomination of the pixel value.                                                                                                                                             |
-| scale              | number                                  | Multiplicator factor of the pixel value to transform into the value (i.e. translate digital number to reflectance).                                                               |
-| offset             | number                                  | Number to be added to the pixel value (after scaling) to transform into the value (i.e. translate digital number to reflectance).                                                 |
-| histogram          | [Histogram Object](#histogram-object)   | Histogram distribution information of the pixels values in the band.                                                                                                              |
+| raster:nodata             | number\|string                          | Pixel values used to identify pixels that are nodata in the band either by the pixel value as a number or `nan`, `inf` or `-inf` (all strings).                                   |
+| raster:sampling           | string                                  | One of `area` or `point`. Indicates whether a pixel value should be assumed to represent a sampling over the region of the pixel or a point sample at the center of the pixel.    |
+| raster:data_type          | string                                  | The data type of the pixels in the band. One of the [data types as described below](#data-types).                                                                                 |
+| raster:bits_per_sample    | number                                  | The actual number of bits used for this band. Normally only present when the number of bits is non-standard for the `datatype`, such as when a 1 bit TIFF is represented as byte. |
+| raster:spatial_resolution | number                                  | Average spatial resolution (in meters) of the pixels in the band.                                                                                                                 |
+| raster:statistics         | [Statistics Object](#statistics-object) | Statistics of all the pixels in the band.                                                                                                                                         |
+| raster:unit               | string                                  | Unit denomination of the pixel value.                                                                                                                                             |
+| raster:scale              | number                                  | Multiplicator factor of the pixel value to transform into the value (i.e. translate digital number to reflectance).                                                               |
+| raster:offset             | number                                  | Number to be added to the pixel value (after scaling) to transform into the value (i.e. translate digital number to reflectance).                                                 |
+| raster:histogram          | [Histogram Object](#histogram-object)   | Histogram distribution information of the pixels values in the band.                                                                                                              |
 
-`scale` and `offset` define parameters to compute another value. The following paragraphs describe some use cases.
+`raster:scale` and `raster:offset` define parameters to compute another value. The following paragraphs describe some use cases.
 
 ### Data Types
 
@@ -116,11 +119,11 @@ For example, the above value conversion is described in the values dictionary as
 "assets": {
   "B4": {
       "title": "TOA radiance band 4",
-      "raster:bands": [{
-        "nodata": 0,
-        "unit": "W⋅sr−1⋅m−2",
-        "scale": 0.0145,
-        "offset": 3.48
+      "bands": [{
+        "raster:nodata": 0,
+        "raster:unit": "W⋅sr−1⋅m−2",
+        "raster:scale": 0.0145,
+        "raster:offset": 3.48
       }]
   }
 }
@@ -154,9 +157,9 @@ In the following value definition example, 185 meters must be substracted from t
 "assets": {
   "WaterLevel": {
       "title": "Water Level at station",
-      "raster:bands": [{
-        "unit": "m",
-        "offset": -185
+      "bands": [{
+        "raster:unit": "m",
+        "raster:offset": -185
       }]
   }
 }

--- a/examples/item-planet.json
+++ b/examples/item-planet.json
@@ -3,7 +3,7 @@
     "https://stac-extensions.github.io/sat/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
-    "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
+    "https://stac-extensions.github.io/eo/v2.0.0-beta.1/schema.json",
     "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
     "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
   ],

--- a/examples/item-planet.json
+++ b/examples/item-planet.json
@@ -42,23 +42,23 @@
         8966,
         4411
       ],
-      "raster:bands": [
+      "bands": [
         {
-          "sampling": "area",
+          "raster:sampling": "area",
           "name": "Red TOA reflectance",
-          "data_type": "uint16",
-          "scale": 0.01,
-          "offset": 0,
-          "nodata": 0,
-          "spatial_resolution": 3,
-          "statistics": {
+          "raster:data_type": "uint16",
+          "raster:scale": 0.01,
+          "raster:offset": 0,
+          "raster:nodata": 0,
+          "raster:spatial_resolution": 3,
+          "raster:statistics": {
             "maximum": 32925,
             "mean": 8498.9400644319,
             "minimum": 1962,
             "stddev": 5056.1292002722,
             "valid_percent": 61.09
           },
-          "histogram": {
+          "raster:histogram": {
             "count": 256,
             "min": 1901.288235294118,
             "max": 32985.71176470588,
@@ -323,21 +323,21 @@
           }
         },
         {
-          "sampling": "area",
+          "raster:sampling": "area",
           "name": "Green TOA reflectance",
-          "data_type": "uint16",
-          "scale": 0.0000196236732904,
-          "offset": 0,
-          "nodata": 0,
-          "spatial_resolution": 3,
-          "statistics": {
+          "raster:data_type": "uint16",
+          "raster:scale": 0.0000196236732904,
+          "raster:offset": 0,
+          "raster:nodata": 0,
+          "raster:spatial_resolution": 3,
+          "raster:statistics": {
             "maximum": 22063,
             "mean": 7185.2123645206,
             "minimum": 3884,
             "stddev": 3799.4562788636,
             "valid_percent": 61.09
           },
-          "histogram": {
+          "raster:histogram": {
             "count": 256,
             "min": 3848.354901960784,
             "max": 22098.64509803921,
@@ -602,21 +602,21 @@
           }
         },
         {
-          "sampling": "area",
+          "raster:sampling": "area",
           "name": "Blue TOA reflectance",
-          "data_type": "uint16",
-          "scale": 0.0000218499248607,
-          "offset": 0,
-          "nodata": 0,
-          "spatial_resolution": 3,
-          "statistics": {
+          "raster:data_type": "uint16",
+          "raster:scale": 0.0000218499248607,
+          "raster:offset": 0,
+          "raster:nodata": 0,
+          "raster:spatial_resolution": 3,
+          "raster:statistics": {
             "maximum": 29693,
             "mean": 5829.583942362,
             "minimum": 1061,
             "stddev": 4683.0650025253,
             "valid_percent": 61.09
           },
-          "histogram": {
+          "raster:histogram": {
             "count": 256,
             "min": 1004.858823529412,
             "max": 29749.14117647059,
@@ -881,21 +881,21 @@
           }
         },
         {
-          "sampling": "area",
+          "raster:sampling": "area",
           "name": "NIR TOA reflectance",
-          "data_type": "uint16",
-          "scale": 0.0000218499248607,
-          "offset": 0,
-          "nodata": 0,
-          "spatial_resolution": 3,
-          "statistics": {
+          "raster:data_type": "uint16",
+          "raster:scale": 0.0000218499248607,
+          "raster:offset": 0,
+          "raster:nodata": 0,
+          "raster:spatial_resolution": 3,
+          "raster:statistics": {
             "maximum": 31836,
             "mean": 6785.2511255265,
             "minimum": 1685,
             "stddev": 3842.4324936707,
             "valid_percent": 61.09
           },
-          "histogram": {
+          "raster:histogram": {
             "count": 256,
             "min": 1625.880392156863,
             "max": 31895.11960784314,

--- a/examples/item-planet.json
+++ b/examples/item-planet.json
@@ -20,12 +20,14 @@
         8966,
         4411
       ],
+      "data_type": "uint16",
+      "nodata": 0,
+      "raster:sampling": "area",
+      "raster:spatial_resolution": 3,
       "bands": [
         {
           "name": "band-1",
           "description": "Red TOA reflectance",
-          "data_type": "uint16",
-          "nodata": 0,
           "statistics": {
             "maximum": 32925,
             "mean": 8498.9400644319,
@@ -35,10 +37,8 @@
           },
           "eo:common_name": "red",
           "eo:center_wavelength": 0.63,
-          "raster:sampling": "area",
           "raster:scale": 0.01,
           "raster:offset": 0,
-          "raster:spatial_resolution": 3,
           "raster:histogram": {
             "count": 256,
             "min": 1901.288235294118,
@@ -306,8 +306,6 @@
         {
           "name": "band-2",
           "description": "Green TOA reflectance",
-          "data_type": "uint16",
-          "nodata": 0,
           "statistics": {
             "maximum": 22063,
             "mean": 7185.2123645206,
@@ -317,10 +315,8 @@
           },
           "eo:common_name": "green",
           "eo:center_wavelength": 0.545,
-          "raster:sampling": "area",
           "raster:scale": 0.0000196236732904,
           "raster:offset": 0,
-          "raster:spatial_resolution": 3,
           "raster:histogram": {
             "count": 256,
             "min": 3848.354901960784,
@@ -588,8 +584,6 @@
         {
           "name": "band-3",
           "description": "Blue TOA reflectance",
-          "data_type": "uint16",
-          "nodata": 0,
           "statistics": {
             "maximum": 29693,
             "mean": 5829.583942362,
@@ -599,10 +593,8 @@
           },
           "eo:common_name": "blue",
           "eo:center_wavelength": 0.485,
-          "raster:sampling": "area",
           "raster:scale": 0.0000218499248607,
           "raster:offset": 0,
-          "raster:spatial_resolution": 3,
           "raster:histogram": {
             "count": 256,
             "min": 1004.858823529412,
@@ -870,8 +862,6 @@
         {
           "name": "band-4",
           "description": "NIR TOA reflectance",
-          "data_type": "uint16",
-          "nodata": 0,
           "statistics": {
             "maximum": 31836,
             "mean": 6785.2511255265,
@@ -881,10 +871,8 @@
           },
           "eo:common_name": "nir",
           "eo:center_wavelength": 0.82,
-          "raster:sampling": "area",
           "raster:scale": 0.0000218499248607,
           "raster:offset": 0,
-          "raster:spatial_resolution": 3,
           "raster:histogram": {
             "count": 256,
             "min": 1625.880392156863,

--- a/examples/item-planet.json
+++ b/examples/item-planet.json
@@ -2,8 +2,8 @@
   "stac_extensions": [
     "https://stac-extensions.github.io/sat/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
-    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
-    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
     "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
     "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
   ],
@@ -16,48 +16,29 @@
         "data"
       ],
       "href": "PT01S00_842547E119_8697242018100100000000MS00_GG001002003/PT01S00_842547E119_8697242018100100000000MS00_GG001002003.tif",
-      "eo:bands": [
-        {
-          "name": "band-1",
-          "common_name": "red",
-          "center_wavelength": 0.63
-        },
-        {
-          "name": "band-2",
-          "common_name": "green",
-          "center_wavelength": 0.545
-        },
-        {
-          "name": "band-3",
-          "common_name": "blue",
-          "center_wavelength": 0.485
-        },
-        {
-          "name": "band-4",
-          "common_name": "nir",
-          "center_wavelength": 0.82
-        }
-      ],
       "proj:shape": [
         8966,
         4411
       ],
       "bands": [
         {
-          "raster:sampling": "area",
-          "name": "Red TOA reflectance",
-          "raster:data_type": "uint16",
-          "raster:scale": 0.01,
-          "raster:offset": 0,
-          "raster:nodata": 0,
-          "raster:spatial_resolution": 3,
-          "raster:statistics": {
+          "name": "band-1",
+          "description": "Red TOA reflectance",
+          "data_type": "uint16",
+          "nodata": 0,
+          "statistics": {
             "maximum": 32925,
             "mean": 8498.9400644319,
             "minimum": 1962,
             "stddev": 5056.1292002722,
             "valid_percent": 61.09
           },
+          "eo:common_name": "red",
+          "eo:center_wavelength": 0.63,
+          "raster:sampling": "area",
+          "raster:scale": 0.01,
+          "raster:offset": 0,
+          "raster:spatial_resolution": 3,
           "raster:histogram": {
             "count": 256,
             "min": 1901.288235294118,
@@ -323,20 +304,23 @@
           }
         },
         {
-          "raster:sampling": "area",
-          "name": "Green TOA reflectance",
-          "raster:data_type": "uint16",
-          "raster:scale": 0.0000196236732904,
-          "raster:offset": 0,
-          "raster:nodata": 0,
-          "raster:spatial_resolution": 3,
-          "raster:statistics": {
+          "name": "band-2",
+          "description": "Green TOA reflectance",
+          "data_type": "uint16",
+          "nodata": 0,
+          "statistics": {
             "maximum": 22063,
             "mean": 7185.2123645206,
             "minimum": 3884,
             "stddev": 3799.4562788636,
             "valid_percent": 61.09
           },
+          "eo:common_name": "green",
+          "eo:center_wavelength": 0.545,
+          "raster:sampling": "area",
+          "raster:scale": 0.0000196236732904,
+          "raster:offset": 0,
+          "raster:spatial_resolution": 3,
           "raster:histogram": {
             "count": 256,
             "min": 3848.354901960784,
@@ -602,20 +586,23 @@
           }
         },
         {
-          "raster:sampling": "area",
-          "name": "Blue TOA reflectance",
-          "raster:data_type": "uint16",
-          "raster:scale": 0.0000218499248607,
-          "raster:offset": 0,
-          "raster:nodata": 0,
-          "raster:spatial_resolution": 3,
-          "raster:statistics": {
+          "name": "band-3",
+          "description": "Blue TOA reflectance",
+          "data_type": "uint16",
+          "nodata": 0,
+          "statistics": {
             "maximum": 29693,
             "mean": 5829.583942362,
             "minimum": 1061,
             "stddev": 4683.0650025253,
             "valid_percent": 61.09
           },
+          "eo:common_name": "blue",
+          "eo:center_wavelength": 0.485,
+          "raster:sampling": "area",
+          "raster:scale": 0.0000218499248607,
+          "raster:offset": 0,
+          "raster:spatial_resolution": 3,
           "raster:histogram": {
             "count": 256,
             "min": 1004.858823529412,
@@ -881,20 +868,23 @@
           }
         },
         {
-          "raster:sampling": "area",
-          "name": "NIR TOA reflectance",
-          "raster:data_type": "uint16",
-          "raster:scale": 0.0000218499248607,
-          "raster:offset": 0,
-          "raster:nodata": 0,
-          "raster:spatial_resolution": 3,
-          "raster:statistics": {
+          "name": "band-4",
+          "description": "NIR TOA reflectance",
+          "data_type": "uint16",
+          "nodata": 0,
+          "statistics": {
             "maximum": 31836,
             "mean": 6785.2511255265,
             "minimum": 1685,
             "stddev": 3842.4324936707,
             "valid_percent": 61.09
           },
+          "eo:common_name": "nir",
+          "eo:center_wavelength": 0.82,
+          "raster:sampling": "area",
+          "raster:scale": 0.0000218499248607,
+          "raster:offset": 0,
+          "raster:spatial_resolution": 3,
           "raster:histogram": {
             "count": 256,
             "min": 1625.880392156863,

--- a/examples/item-sentinel2.json
+++ b/examples/item-sentinel2.json
@@ -2,9 +2,9 @@
   "type": "Feature",
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
-    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
     "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
   ],
   "id": "S2B_33SVB_20210221_0_L2A",
@@ -57,8 +57,7 @@
     "sentinel:sequence": "0",
     "sentinel:product_id": "S2B_MSIL2A_20210221T095029_N0214_R079_T33SVB_20210221T115149",
     "sentinel:data_coverage": 100,
-    "eo:cloud_cover": 21.22,
-    "sentinel:valid_cloud_cover": true
+    "eo:cloud_cover": 21.22
   },
   "collection": "sentinel-s2-l2a-cogs",
   "assets": {
@@ -77,24 +76,24 @@
         "overview"
       ],
       "gsd": 10,
-      "eo:bands": [
+      "bands": [
         {
           "name": "B04",
-          "common_name": "red",
-          "center_wavelength": 0.6645,
-          "full_width_half_max": 0.038
+          "eo:common_name": "red",
+          "eo:center_wavelength": 0.6645,
+          "eo:full_width_half_max": 0.038
         },
         {
           "name": "B03",
-          "common_name": "green",
-          "center_wavelength": 0.56,
-          "full_width_half_max": 0.045
+          "eo:common_name": "green",
+          "eo:center_wavelength": 0.56,
+          "eo:full_width_half_max": 0.045
         },
         {
           "name": "B02",
-          "common_name": "blue",
-          "center_wavelength": 0.4966,
-          "full_width_half_max": 0.098
+          "eo:common_name": "blue",
+          "eo:center_wavelength": 0.4966,
+          "eo:full_width_half_max": 0.098
         }
       ],
       "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/L2A_PVI.tif",
@@ -137,24 +136,24 @@
         "overview"
       ],
       "gsd": 10,
-      "eo:bands": [
+      "bands": [
         {
           "name": "B04",
-          "common_name": "red",
-          "center_wavelength": 0.6645,
-          "full_width_half_max": 0.038
+          "eo:common_name": "red",
+          "eo:center_wavelength": 0.6645,
+          "eo:full_width_half_max": 0.038
         },
         {
           "name": "B03",
-          "common_name": "green",
-          "center_wavelength": 0.56,
-          "full_width_half_max": 0.045
+          "eo:common_name": "green",
+          "eo:center_wavelength": 0.56,
+          "eo:full_width_half_max": 0.045
         },
         {
           "name": "B02",
-          "common_name": "blue",
-          "center_wavelength": 0.4966,
-          "full_width_half_max": 0.098
+          "eo:common_name": "blue",
+          "eo:center_wavelength": 0.4966,
+          "eo:full_width_half_max": 0.098
         }
       ],
       "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/TCI.tif",
@@ -181,14 +180,6 @@
         "data"
       ],
       "gsd": 60,
-      "eo:bands": [
-        {
-          "name": "B01",
-          "common_name": "coastal",
-          "center_wavelength": 0.4439,
-          "full_width_half_max": 0.027
-        }
-      ],
       "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B01.tif",
       "proj:shape": [
         1830,
@@ -207,17 +198,21 @@
       ],
       "bands": [
         {
-          "raster:data_type": "uint16",
-          "raster:spatial_resolution": 60,
-          "raster:bits_per_sample": 15,
-          "raster:nodata": 0,
-          "raster:statistics": {
+          "name": "B01",
+          "data_type": "uint16",
+          "nodata": 0,
+          "statistics": {
             "minimum": 1,
             "maximum": 20567,
             "mean": 2339.4759595597,
             "stddev": 3026.6973619954,
             "valid_percent": 99.83
-          }
+          },
+          "eo:common_name": "coastal",
+          "eo:center_wavelength": 0.4439,
+          "eo:full_width_half_max": 0.027,
+          "raster:spatial_resolution": 60,
+          "raster:bits_per_sample": 15
         }
       ]
     },
@@ -228,14 +223,6 @@
         "data"
       ],
       "gsd": 10,
-      "eo:bands": [
-        {
-          "name": "B02",
-          "common_name": "blue",
-          "center_wavelength": 0.4966,
-          "full_width_half_max": 0.098
-        }
-      ],
       "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B02.tif",
       "proj:shape": [
         10980,
@@ -254,17 +241,21 @@
       ],
       "bands": [
         {
-          "raster:data_type": "uint16",
-          "raster:spatial_resolution": 10,
-          "raster:bits_per_sample": 15,
-          "raster:nodata": 0,
-          "raster:statistics": {
+          "name": "B02",
+          "data_type": "uint16",
+          "nodata": 0,
+          "statistics": {
             "minimum": 1,
             "maximum": 19264,
             "mean": 2348.069117847,
             "stddev": 2916.5446249911,
             "valid_percent": 99.99
-          }
+          },
+          "eo:common_name": "blue",
+          "eo:center_wavelength": 0.4966,
+          "eo:full_width_half_max": 0.098,
+          "raster:spatial_resolution": 10,
+          "raster:bits_per_sample": 15
         }
       ]
     },
@@ -275,14 +266,6 @@
         "data"
       ],
       "gsd": 10,
-      "eo:bands": [
-        {
-          "name": "B03",
-          "common_name": "green",
-          "center_wavelength": 0.56,
-          "full_width_half_max": 0.045
-        }
-      ],
       "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B03.tif",
       "proj:shape": [
         10980,
@@ -301,17 +284,21 @@
       ],
       "bands": [
         {
-          "raster:data_type": "uint16",
-          "raster:spatial_resolution": 10,
-          "raster:bits_per_sample": 15,
-          "raster:nodata": 0,
-          "raster:statistics": {
+          "name": "B03",
+          "data_type": "uint16",
+          "nodata": 0,
+          "statistics": {
             "minimum": 1,
             "maximum": 18064,
             "mean": 2384.4680007438,
             "stddev": 2675.410513295,
             "valid_percent": 99.999
-          }
+          },
+          "eo:common_name": "green",
+          "eo:center_wavelength": 0.56,
+          "eo:full_width_half_max": 0.045,
+          "raster:spatial_resolution": 10,
+          "raster:bits_per_sample": 15
         }
       ]
     },
@@ -322,14 +309,6 @@
         "data"
       ],
       "gsd": 10,
-      "eo:bands": [
-        {
-          "name": "B04",
-          "common_name": "red",
-          "center_wavelength": 0.6645,
-          "full_width_half_max": 0.038
-        }
-      ],
       "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B04.tif",
       "proj:shape": [
         10980,
@@ -348,17 +327,21 @@
       ],
       "bands": [
         {
-          "raster:data_type": "uint16",
-          "raster:spatial_resolution": 10,
-          "raster:bits_per_sample": 15,
-          "raster:nodata": 0,
-          "raster:statistics": {
+          "name": "B04",
+          "data_type": "uint16",
+          "nodata": 0,
+          "statistics": {
             "minimum": 1,
             "maximum": 17200,
             "mean": 2273.9667970732,
             "stddev": 2618.272802792,
             "valid_percent": 99.999
-          }
+          },
+          "eo:common_name": "red",
+          "eo:center_wavelength": 0.6645,
+          "eo:full_width_half_max": 0.038,
+          "raster:spatial_resolution": 10,
+          "raster:bits_per_sample": 15
         }
       ]
     },
@@ -369,13 +352,6 @@
         "data"
       ],
       "gsd": 20,
-      "eo:bands": [
-        {
-          "name": "B05",
-          "center_wavelength": 0.7039,
-          "full_width_half_max": 0.019
-        }
-      ],
       "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B05.tif",
       "proj:shape": [
         5490,
@@ -394,17 +370,20 @@
       ],
       "bands": [
         {
-          "raster:data_type": "uint16",
-          "raster:spatial_resolution": 20,
-          "raster:bits_per_sample": 15,
-          "raster:nodata": 0,
-          "raster:statistics": {
+          "name": "B05",
+          "data_type": "uint16",
+          "nodata": 0,
+          "statistics": {
             "minimum": 1,
             "maximum": 16842,
             "mean": 2634.1490243416,
             "stddev": 2634.1490243416,
             "valid_percent": 99.999
-          }
+          },
+          "eo:center_wavelength": 0.7039,
+          "eo:full_width_half_max": 0.019,
+          "raster:spatial_resolution": 20,
+          "raster:bits_per_sample": 15
         }
       ]
     },
@@ -415,13 +394,6 @@
         "data"
       ],
       "gsd": 20,
-      "eo:bands": [
-        {
-          "name": "B06",
-          "center_wavelength": 0.7402,
-          "full_width_half_max": 0.018
-        }
-      ],
       "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B06.tif",
       "proj:shape": [
         5490,
@@ -440,215 +412,21 @@
       ],
       "bands": [
         {
-          "raster:data_type": "uint16",
-          "raster:spatial_resolution": 20,
-          "raster:bits_per_sample": 15,
-          "raster:nodata": 0,
-          "raster:statistics": {
+          "name": "B06",
+          "data_type": "uint16",
+          "nodata": 0,
+          "statistics": {
             "minimum": 1,
             "maximum": 16502,
             "mean": 3329.8844628619,
             "stddev": 2303.0096294469,
             "valid_percent": 99.999
-          }
+          },
+          "eo:center_wavelength": 0.7402,
+          "eo:full_width_half_max": 0.018,
+          "raster:spatial_resolution": 20,
+          "raster:bits_per_sample": 15
         }
-      ]
-    },
-    "B07": {
-      "title": "Band 7 BOA reflectance",
-      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
-      "roles": [
-        "data"
-      ],
-      "gsd": 20,
-      "eo:bands": [
-        {
-          "name": "B07",
-          "center_wavelength": 0.7825,
-          "full_width_half_max": 0.028
-        }
-      ],
-      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B07.tif",
-      "proj:shape": [
-        5490,
-        5490
-      ],
-      "proj:transform": [
-        20,
-        0,
-        399960,
-        0,
-        -20,
-        4200000,
-        0,
-        0,
-        1
-      ]
-    },
-    "B08": {
-      "title": "Band 8 (nir) BOA reflectance",
-      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
-      "roles": [
-        "data"
-      ],
-      "gsd": 10,
-      "eo:bands": [
-        {
-          "name": "B08",
-          "common_name": "nir",
-          "center_wavelength": 0.8351,
-          "full_width_half_max": 0.145
-        }
-      ],
-      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B08.tif",
-      "proj:shape": [
-        10980,
-        10980
-      ],
-      "proj:transform": [
-        10,
-        0,
-        399960,
-        0,
-        -10,
-        4200000,
-        0,
-        0,
-        1
-      ]
-    },
-    "B8A": {
-      "title": "Band 8A BOA reflectance",
-      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
-      "roles": [
-        "data"
-      ],
-      "gsd": 20,
-      "eo:bands": [
-        {
-          "name": "B8A",
-          "center_wavelength": 0.8648,
-          "full_width_half_max": 0.033
-        }
-      ],
-      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B8A.tif",
-      "proj:shape": [
-        5490,
-        5490
-      ],
-      "proj:transform": [
-        20,
-        0,
-        399960,
-        0,
-        -20,
-        4200000,
-        0,
-        0,
-        1
-      ]
-    },
-    "B09": {
-      "title": "Band 9 BOA reflectance",
-      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
-      "roles": [
-        "data"
-      ],
-      "gsd": 60,
-      "eo:bands": [
-        {
-          "name": "B09",
-          "center_wavelength": 0.945,
-          "full_width_half_max": 0.026
-        }
-      ],
-      "bands": [
-        {
-          "raster:data_type": "uint16",
-          "raster:spatial_resolution": 60,
-          "raster:bits_per_sample": 15,
-          "raster:nodata": "nan"
-        }
-      ],
-      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B09.tif",
-      "proj:shape": [
-        1830,
-        1830
-      ],
-      "proj:transform": [
-        60,
-        0,
-        399960,
-        0,
-        -60,
-        4200000,
-        0,
-        0,
-        1
-      ]
-    },
-    "B11": {
-      "title": "Band 11 (swir16) BOA reflectance",
-      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
-      "roles": [
-        "data"
-      ],
-      "gsd": 20,
-      "eo:bands": [
-        {
-          "name": "B11",
-          "common_name": "swir16",
-          "center_wavelength": 1.6137,
-          "full_width_half_max": 0.143
-        }
-      ],
-      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B11.tif",
-      "proj:shape": [
-        5490,
-        5490
-      ],
-      "proj:transform": [
-        20,
-        0,
-        399960,
-        0,
-        -20,
-        4200000,
-        0,
-        0,
-        1
-      ]
-    },
-    "B12": {
-      "title": "Band 12 (swir22) BOA reflectance",
-      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
-      "roles": [
-        "data"
-      ],
-      "gsd": 20,
-      "eo:bands": [
-        {
-          "name": "B12",
-          "common_name": "swir22",
-          "center_wavelength": 2.22024,
-          "full_width_half_max": 0.242
-        }
-      ],
-      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B12.tif",
-      "proj:shape": [
-        5490,
-        5490
-      ],
-      "proj:transform": [
-        20,
-        0,
-        399960,
-        0,
-        -20,
-        4200000,
-        0,
-        0,
-        1
       ]
     },
     "AOT": {

--- a/examples/item-sentinel2.json
+++ b/examples/item-sentinel2.json
@@ -76,6 +76,7 @@
         "overview"
       ],
       "gsd": 10,
+      "raster:spatial_resolution": 10,
       "bands": [
         {
           "name": "B04",
@@ -174,13 +175,22 @@
       ]
     },
     "B01": {
+      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B01.tif",
       "title": "Band 1 (coastal) BOA reflectance",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "roles": [
         "data"
       ],
       "gsd": 60,
-      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B01.tif",
+      "data_type": "uint16",
+      "nodata": 0,
+      "statistics": {
+        "minimum": 1,
+        "maximum": 20567,
+        "mean": 2339.4759595597,
+        "stddev": 3026.6973619954,
+        "valid_percent": 99.83
+      },
       "proj:shape": [
         1830,
         1830
@@ -196,34 +206,29 @@
         0,
         1
       ],
-      "bands": [
-        {
-          "name": "B01",
-          "data_type": "uint16",
-          "nodata": 0,
-          "statistics": {
-            "minimum": 1,
-            "maximum": 20567,
-            "mean": 2339.4759595597,
-            "stddev": 3026.6973619954,
-            "valid_percent": 99.83
-          },
-          "eo:common_name": "coastal",
-          "eo:center_wavelength": 0.4439,
-          "eo:full_width_half_max": 0.027,
-          "raster:spatial_resolution": 60,
-          "raster:bits_per_sample": 15
-        }
-      ]
+      "eo:common_name": "coastal",
+      "eo:center_wavelength": 0.4439,
+      "eo:full_width_half_max": 0.027,
+      "raster:spatial_resolution": 60,
+      "raster:bits_per_sample": 15
     },
     "B02": {
+      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B02.tif",
       "title": "Band 2 (blue) BOA reflectance",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "roles": [
         "data"
       ],
       "gsd": 10,
-      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B02.tif",
+      "data_type": "uint16",
+      "nodata": 0,
+      "statistics": {
+        "minimum": 1,
+        "maximum": 19264,
+        "mean": 2348.069117847,
+        "stddev": 2916.5446249911,
+        "valid_percent": 99.99
+      },
       "proj:shape": [
         10980,
         10980
@@ -239,34 +244,29 @@
         0,
         1
       ],
-      "bands": [
-        {
-          "name": "B02",
-          "data_type": "uint16",
-          "nodata": 0,
-          "statistics": {
-            "minimum": 1,
-            "maximum": 19264,
-            "mean": 2348.069117847,
-            "stddev": 2916.5446249911,
-            "valid_percent": 99.99
-          },
-          "eo:common_name": "blue",
-          "eo:center_wavelength": 0.4966,
-          "eo:full_width_half_max": 0.098,
-          "raster:spatial_resolution": 10,
-          "raster:bits_per_sample": 15
-        }
-      ]
+      "eo:common_name": "blue",
+      "eo:center_wavelength": 0.4966,
+      "eo:full_width_half_max": 0.098,
+      "raster:spatial_resolution": 10,
+      "raster:bits_per_sample": 15
     },
     "B03": {
+      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B03.tif",
       "title": "Band 3 (green) BOA reflectance",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "roles": [
         "data"
       ],
       "gsd": 10,
-      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B03.tif",
+      "data_type": "uint16",
+      "nodata": 0,
+      "statistics": {
+        "minimum": 1,
+        "maximum": 18064,
+        "mean": 2384.4680007438,
+        "stddev": 2675.410513295,
+        "valid_percent": 99.999
+      },
       "proj:shape": [
         10980,
         10980
@@ -282,34 +282,29 @@
         0,
         1
       ],
-      "bands": [
-        {
-          "name": "B03",
-          "data_type": "uint16",
-          "nodata": 0,
-          "statistics": {
-            "minimum": 1,
-            "maximum": 18064,
-            "mean": 2384.4680007438,
-            "stddev": 2675.410513295,
-            "valid_percent": 99.999
-          },
-          "eo:common_name": "green",
-          "eo:center_wavelength": 0.56,
-          "eo:full_width_half_max": 0.045,
-          "raster:spatial_resolution": 10,
-          "raster:bits_per_sample": 15
-        }
-      ]
+      "eo:common_name": "green",
+      "eo:center_wavelength": 0.56,
+      "eo:full_width_half_max": 0.045,
+      "raster:spatial_resolution": 10,
+      "raster:bits_per_sample": 15
     },
     "B04": {
+      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B04.tif",
       "title": "Band 4 (red) BOA reflectance",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "roles": [
         "data"
       ],
       "gsd": 10,
-      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B04.tif",
+      "data_type": "uint16",
+      "nodata": 0,
+      "statistics": {
+        "minimum": 1,
+        "maximum": 17200,
+        "mean": 2273.9667970732,
+        "stddev": 2618.272802792,
+        "valid_percent": 99.999
+      },
       "proj:shape": [
         10980,
         10980
@@ -325,34 +320,29 @@
         0,
         1
       ],
-      "bands": [
-        {
-          "name": "B04",
-          "data_type": "uint16",
-          "nodata": 0,
-          "statistics": {
-            "minimum": 1,
-            "maximum": 17200,
-            "mean": 2273.9667970732,
-            "stddev": 2618.272802792,
-            "valid_percent": 99.999
-          },
-          "eo:common_name": "red",
-          "eo:center_wavelength": 0.6645,
-          "eo:full_width_half_max": 0.038,
-          "raster:spatial_resolution": 10,
-          "raster:bits_per_sample": 15
-        }
-      ]
+      "eo:common_name": "red",
+      "eo:center_wavelength": 0.6645,
+      "eo:full_width_half_max": 0.038,
+      "raster:spatial_resolution": 10,
+      "raster:bits_per_sample": 15
     },
     "B05": {
+      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B05.tif",
       "title": "Band 5 BOA reflectance",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "roles": [
         "data"
       ],
       "gsd": 20,
-      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B05.tif",
+      "data_type": "uint16",
+      "nodata": 0,
+      "statistics": {
+        "minimum": 1,
+        "maximum": 16842,
+        "mean": 2634.1490243416,
+        "stddev": 2634.1490243416,
+        "valid_percent": 99.999
+      },
       "proj:shape": [
         5490,
         5490
@@ -368,33 +358,28 @@
         0,
         1
       ],
-      "bands": [
-        {
-          "name": "B05",
-          "data_type": "uint16",
-          "nodata": 0,
-          "statistics": {
-            "minimum": 1,
-            "maximum": 16842,
-            "mean": 2634.1490243416,
-            "stddev": 2634.1490243416,
-            "valid_percent": 99.999
-          },
-          "eo:center_wavelength": 0.7039,
-          "eo:full_width_half_max": 0.019,
-          "raster:spatial_resolution": 20,
-          "raster:bits_per_sample": 15
-        }
-      ]
+      "eo:center_wavelength": 0.7039,
+      "eo:full_width_half_max": 0.019,
+      "raster:spatial_resolution": 20,
+      "raster:bits_per_sample": 15
     },
     "B06": {
+      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B06.tif",
       "title": "Band 6 BOA reflectance",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "roles": [
         "data"
       ],
       "gsd": 20,
-      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B06.tif",
+      "data_type": "uint16",
+      "nodata": 0,
+      "statistics": {
+        "minimum": 1,
+        "maximum": 16502,
+        "mean": 3329.8844628619,
+        "stddev": 2303.0096294469,
+        "valid_percent": 99.999
+      },
       "proj:shape": [
         5490,
         5490
@@ -410,70 +395,10 @@
         0,
         1
       ],
-      "bands": [
-        {
-          "name": "B06",
-          "data_type": "uint16",
-          "nodata": 0,
-          "statistics": {
-            "minimum": 1,
-            "maximum": 16502,
-            "mean": 3329.8844628619,
-            "stddev": 2303.0096294469,
-            "valid_percent": 99.999
-          },
-          "eo:center_wavelength": 0.7402,
-          "eo:full_width_half_max": 0.018,
-          "raster:spatial_resolution": 20,
-          "raster:bits_per_sample": 15
-        }
-      ]
-    },
-    "AOT": {
-      "title": "Aerosol Optical Thickness (AOT)",
-      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
-      "roles": [
-        "data"
-      ],
-      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/AOT.tif",
-      "proj:shape": [
-        1830,
-        1830
-      ],
-      "proj:transform": [
-        60,
-        0,
-        399960,
-        0,
-        -60,
-        4200000,
-        0,
-        0,
-        1
-      ]
-    },
-    "WVP": {
-      "title": "Water Vapour (WVP)",
-      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
-      "roles": [
-        "data"
-      ],
-      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/WVP.tif",
-      "proj:shape": [
-        10980,
-        10980
-      ],
-      "proj:transform": [
-        10,
-        0,
-        399960,
-        0,
-        -10,
-        4200000,
-        0,
-        0,
-        1
-      ]
+      "eo:center_wavelength": 0.7402,
+      "eo:full_width_half_max": 0.018,
+      "raster:spatial_resolution": 20,
+      "raster:bits_per_sample": 15
     },
     "SCL": {
       "title": "Scene Classification Map (SCL)",
@@ -496,7 +421,8 @@
         0,
         0,
         1
-      ]
+      ],
+      "raster:spatial_resolution": 20
     }
   },
   "links": [

--- a/examples/item-sentinel2.json
+++ b/examples/item-sentinel2.json
@@ -2,7 +2,7 @@
   "type": "Feature",
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
+    "https://stac-extensions.github.io/eo/v2.0.0-beta.1/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
     "https://stac-extensions.github.io/raster/v1.1.0/schema.json"

--- a/examples/item-sentinel2.json
+++ b/examples/item-sentinel2.json
@@ -205,13 +205,13 @@
         0,
         1
       ],
-      "raster:bands": [
+      "bands": [
         {
-          "data_type": "uint16",
-          "spatial_resolution": 60,
-          "bits_per_sample": 15,
-          "nodata": 0,
-          "statistics": {
+          "raster:data_type": "uint16",
+          "raster:spatial_resolution": 60,
+          "raster:bits_per_sample": 15,
+          "raster:nodata": 0,
+          "raster:statistics": {
             "minimum": 1,
             "maximum": 20567,
             "mean": 2339.4759595597,
@@ -252,13 +252,13 @@
         0,
         1
       ],
-      "raster:bands": [
+      "bands": [
         {
-          "data_type": "uint16",
-          "spatial_resolution": 10,
-          "bits_per_sample": 15,
-          "nodata": 0,
-          "statistics": {
+          "raster:data_type": "uint16",
+          "raster:spatial_resolution": 10,
+          "raster:bits_per_sample": 15,
+          "raster:nodata": 0,
+          "raster:statistics": {
             "minimum": 1,
             "maximum": 19264,
             "mean": 2348.069117847,
@@ -299,13 +299,13 @@
         0,
         1
       ],
-      "raster:bands": [
+      "bands": [
         {
-          "data_type": "uint16",
-          "spatial_resolution": 10,
-          "bits_per_sample": 15,
-          "nodata": 0,
-          "statistics": {
+          "raster:data_type": "uint16",
+          "raster:spatial_resolution": 10,
+          "raster:bits_per_sample": 15,
+          "raster:nodata": 0,
+          "raster:statistics": {
             "minimum": 1,
             "maximum": 18064,
             "mean": 2384.4680007438,
@@ -346,13 +346,13 @@
         0,
         1
       ],
-      "raster:bands": [
+      "bands": [
         {
-          "data_type": "uint16",
-          "spatial_resolution": 10,
-          "bits_per_sample": 15,
-          "nodata": 0,
-          "statistics": {
+          "raster:data_type": "uint16",
+          "raster:spatial_resolution": 10,
+          "raster:bits_per_sample": 15,
+          "raster:nodata": 0,
+          "raster:statistics": {
             "minimum": 1,
             "maximum": 17200,
             "mean": 2273.9667970732,
@@ -392,13 +392,13 @@
         0,
         1
       ],
-      "raster:bands": [
+      "bands": [
         {
-          "data_type": "uint16",
-          "spatial_resolution": 20,
-          "bits_per_sample": 15,
-          "nodata": 0,
-          "statistics": {
+          "raster:data_type": "uint16",
+          "raster:spatial_resolution": 20,
+          "raster:bits_per_sample": 15,
+          "raster:nodata": 0,
+          "raster:statistics": {
             "minimum": 1,
             "maximum": 16842,
             "mean": 2634.1490243416,
@@ -438,13 +438,13 @@
         0,
         1
       ],
-      "raster:bands": [
+      "bands": [
         {
-          "data_type": "uint16",
-          "spatial_resolution": 20,
-          "bits_per_sample": 15,
-          "nodata": 0,
-          "statistics": {
+          "raster:data_type": "uint16",
+          "raster:spatial_resolution": 20,
+          "raster:bits_per_sample": 15,
+          "raster:nodata": 0,
+          "raster:statistics": {
             "minimum": 1,
             "maximum": 16502,
             "mean": 3329.8844628619,
@@ -562,12 +562,12 @@
           "full_width_half_max": 0.026
         }
       ],
-      "raster:bands": [
+      "bands": [
         {
-          "data_type": "uint16",
-          "spatial_resolution": 60,
-          "bits_per_sample": 15,
-          "nodata": "nan"
+          "raster:data_type": "uint16",
+          "raster:spatial_resolution": 60,
+          "raster:bits_per_sample": 15,
+          "raster:nodata": "nan"
         }
       ],
       "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B09.tif",
@@ -718,20 +718,6 @@
         0,
         0,
         1
-      ]
-    }
-  },
-  "virtual:assets": {
-    "SIR": {
-      "title": "Shortwave Infra-red",
-      "raster:range": [
-        0,
-        10000
-      ],
-      "href": [
-        "#B12",
-        "#B8A",
-        "#B04"
       ]
     }
   },

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -3,56 +3,82 @@
   "$id": "https://stac-extensions.github.io/raster/v1.1.0/schema.json#",
   "title": "raster Extension",
   "description": "STAC Raster Extension for STAC Items.",
+  "type": "object",
+  "required": [
+    "stac_extensions"
+  ],
+  "properties": {
+    "stac_extensions": {
+      "type": "array",
+      "contains": {
+        "const": "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
+      }
+    }
+  },
   "oneOf": [
     {
-      "$comment": "This is the schema for STAC extension raster in Items.",
-      "allOf": [
-        {
+      "$comment": "This is the schema for Items",
+      "type": "object",
+      "required": [
+        "type",
+        "properties",
+        "assets"
+      ],
+      "properties": {
+        "type": {
+          "const": "Feature"
+        },
+        "properties": {
+          "$ref": "#/definitions/fields"
+        },
+        "assets": {
           "type": "object",
-          "required": [
-            "type",
-            "assets"
-          ],
+          "additionalProperties": {
+            "$ref": "#/definitions/fields"
+          }
+        }
+      },
+      "anyOf": [
+        {
           "properties": {
-            "type": {
-              "const": "Feature"
-            },
-            "assets": {
-              "type": "object",
-              "additionalProperties": {
-                "$ref": "#/definitions/assetfields"
-              }
+            "properties": {
+              "$ref": "#/definitions/require_any"
             }
           }
         },
         {
-          "$ref": "#/definitions/stac_extensions"
+          "$ref": "#/definitions/require_in_assets"
         }
       ]
     },
     {
       "$comment": "This is the schema for STAC Collections.",
-      "allOf": [
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "const": "Collection"
+        },
+        "assets": {
+          "$ref": "#/definitions/fields"
+        },
+        "item_assets": {
+          "$ref": "#/definitions/fields"
+        }
+      },
+      "anyOf": [
         {
-          "type": "object",
-          "required": [
-            "type"
-          ],
+          "$ref": "#/definitions/require_in_item_assets"
+        },
+        {
+          "$ref": "#/definitions/require_in_assets"
+        },
+        {
           "properties": {
-            "type": {
-              "const": "Collection"
-            },
-            "assets": {
-              "type": "object",
-              "additionalProperties": {
-                "$ref": "#/definitions/assetfields"
-              }
-            },
-            "item_assets": {
-              "type": "object",
-              "additionalProperties": {
-                "$ref": "#/definitions/assetfields"
-              }
+            "summaries": {
+              "$ref": "#/definitions/require_any"
             }
           }
         }
@@ -60,175 +86,217 @@
     }
   ],
   "definitions": {
-    "stac_extensions": {
-      "type": "object",
+    "require_any": {
+      "anyOf": [
+        {"required": ["raster:data_type"]},
+        {"required": ["raster:unit"]},
+        {"required": ["raster:bits_per_sample"]},
+        {"required": ["raster:sampling"]},
+        {"required": ["raster:nodata"]},
+        {"required": ["raster:scale"]},
+        {"required": ["raster:offset"]},
+        {"required": ["raster:spatial_resolution"]},
+        {"required": ["raster:statistics"]},
+        {"required": ["raster:histogram"]},
+        {
+          "$ref": "#/definitions/require_in_bands"
+        }
+      ]
+    },
+    "require_in_bands": {
       "required": [
-        "stac_extensions"
+        "bands"
       ],
       "properties": {
-        "stac_extensions": {
-          "type": "array",
-          "contains": {
-            "const": "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
+        "bands": {
+          "not": {
+            "additionalProperties": {
+              "not": {
+                "$ref": "#/definitions/require_any"
+              }
+            }
           }
         }
       }
     },
-    "assetfields": {
+    "require_in_assets": {
+      "required": [
+        "assets"
+      ],
+      "properties": {
+        "assets": {
+          "not": {
+            "additionalProperties": {
+              "not": {
+                "$ref": "#/definitions/require_any"
+              }
+            }
+          }
+        }
+      }
+    },
+    "require_in_item_assets": {
+      "required": [
+        "item_assets"
+      ],
+      "properties": {
+        "item_assets": {
+          "not": {
+            "additionalProperties": {
+              "not": {
+                "$ref": "#/definitions/require_any"
+              }
+            }
+          }
+        }
+      }
+    },
+    "fields": {
       "type": "object",
       "properties": {
-        "raster:bands": {
-          "$ref": "#/definitions/bands"
+        "bands": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/fields"
+          }
+        },
+        "raster:data_type": {
+          "title": "Data type of the band",
+          "type": "string",
+          "enum": [
+            "int8",
+            "int16",
+            "int32",
+            "int64",
+            "uint8",
+            "uint16",
+            "uint32",
+            "uint64",
+            "float16",
+            "float32",
+            "float64",
+            "cint16",
+            "cint32",
+            "cfloat32",
+            "cfloat64",
+            "other"
+          ]
+        },
+        "raster:unit": {
+          "title": "Unit denomination of the pixel value",
+          "type": "string"
+        },
+        "raster:bits_per_sample": {
+          "title": "The actual number of bits used for this band",
+          "type": "integer"
+        },
+        "raster:sampling": {
+          "title": "Pixel sampling in the band",
+          "type": "string",
+          "enum": [
+            "area",
+            "point"
+          ]
+        },
+        "raster:nodata": {
+          "title": "No data pixel value",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string",
+              "enum": [
+                "nan",
+                "inf",
+                "-inf"
+              ]
+            }
+          ]
+        },
+        "raster:scale": {
+          "title": "multiplicator factor of the pixel value to transform into the value",
+          "type": "number"
+        },
+        "raster:offset": {
+          "title": "number to be added to the pixel value to transform into the value",
+          "type": "number"
+        },
+        "raster:spatial_resolution": {
+          "title": "Average spatial resolution (in meters) of the pixels in the band",
+          "type": "number"
+        },
+        "raster:statistics": {
+          "title": "Statistics",
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": false,
+          "properties": {
+            "mean": {
+              "title": "Mean value of all the pixels in the band",
+              "type": "number"
+            },
+            "minimum": {
+              "title": "Minimum value of all the pixels in the band",
+              "type": "number"
+            },
+            "maximum": {
+              "title": "Maximum value of all the pixels in the band",
+              "type": "number"
+            },
+            "stddev": {
+              "title": "Standard deviation value of all the pixels in the band",
+              "type": "number"
+            },
+            "valid_percent": {
+              "title": "Percentage of valid (not nodata) pixel",
+              "type": "number"
+            }
+          }
+        },
+        "raster:histogram": {
+          "title": "Histogram",
+          "type": "object",
+          "additionalItems": false,
+          "required": [
+            "count",
+            "min",
+            "max",
+            "buckets"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "count": {
+              "title": "number of buckets",
+              "type": "number"
+            },
+            "min": {
+              "title": "Minimum value of the buckets",
+              "type": "number"
+            },
+            "max": {
+              "title": "Maximum value of the buckets",
+              "type": "number"
+            },
+            "buckets": {
+              "title": "distribution buckets",
+              "type": "array",
+              "minItems": 3,
+              "items": {
+                "title": "number of pixels in the bucket",
+                "type": "integer"
+              }
+            }
+          }
         }
       },
       "patternProperties": {
-        "^(?!raster:)": {
-          "$comment": "Above, change `template` to the prefix of this extension"
-        }
+        "^(?!raster:)": {}
       },
       "additionalProperties": false
-    },
-    "bands": {
-      "title": "Bands",
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "title": "Band",
-        "type": "object",
-        "minProperties": 1,
-        "additionalProperties": true,
-        "properties": {
-          "data_type": {
-            "title": "Data type of the band",
-            "type": "string",
-            "enum": [
-              "int8",
-              "int16",
-              "int32",
-              "int64",
-              "uint8",
-              "uint16",
-              "uint32",
-              "uint64",
-              "float16",
-              "float32",
-              "float64",
-              "cint16",
-              "cint32",
-              "cfloat32",
-              "cfloat64",
-              "other"
-            ]
-          },
-          "unit": {
-            "title": "Unit denomination of the pixel value",
-            "type": "string"
-          },
-          "bits_per_sample": {
-            "title": "The actual number of bits used for this band",
-            "type": "integer"
-          },
-          "sampling": {
-            "title": "Pixel sampling in the band",
-            "type": "string",
-            "enum": [
-              "area",
-              "point"
-            ]
-          },
-          "nodata": {
-            "title": "No data pixel value",
-            "oneOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "string",
-                "enum": [
-                  "nan",
-                  "inf",
-                  "-inf"
-                ]
-              }
-            ]
-          },
-          "scale": {
-            "title": "multiplicator factor of the pixel value to transform into the value",
-            "type": "number"
-          },
-          "offset": {
-            "title": "number to be added to the pixel value to transform into the value",
-            "type": "number"
-          },
-          "spatial_resolution": {
-            "title": "Average spatial resolution (in meters) of the pixels in the band",
-            "type": "number"
-          },
-          "statistics": {
-            "title": "Statistics",
-            "type": "object",
-            "minProperties": 1,
-            "additionalProperties": false,
-            "properties": {
-              "mean": {
-                "title": "Mean value of all the pixels in the band",
-                "type": "number"
-              },
-              "minimum": {
-                "title": "Minimum value of all the pixels in the band",
-                "type": "number"
-              },
-              "maximum": {
-                "title": "Maximum value of all the pixels in the band",
-                "type": "number"
-              },
-              "stddev": {
-                "title": "Standard deviation value of all the pixels in the band",
-                "type": "number"
-              },
-              "valid_percent": {
-                "title": "Percentage of valid (not nodata) pixel",
-                "type": "number"
-              }
-            }
-          },
-          "histogram": {
-            "title": "Histogram",
-            "type": "object",
-            "additionalItems": false,
-            "required": [
-              "count",
-              "min",
-              "max",
-              "buckets"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "count": {
-                "title": "number of buckets",
-                "type": "number"
-              },
-              "min": {
-                "title": "Minimum value of the buckets",
-                "type": "number"
-              },
-              "max": {
-                "title": "Maximum value of the buckets",
-                "type": "number"
-              },
-              "buckets": {
-                "title": "distribution buckets",
-                "type": "array",
-                "minItems": 3,
-                "items": {
-                  "title": "number of pixels in the bucket",
-                  "type": "integer"
-                }
-              }
-            }
-          }
-        }
-      }
     }
   }
 }
+
+
+

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://stac-extensions.github.io/raster/v1.1.0/schema.json#",
-  "title": "raster Extension",
+  "title": "Raster Extension",
   "description": "STAC Raster Extension for STAC Items.",
   "type": "object",
   "required": [
@@ -17,7 +17,7 @@
   },
   "oneOf": [
     {
-      "$comment": "This is the schema for Items",
+      "$comment": "This is the schema for STAC Items.",
       "type": "object",
       "required": [
         "type",
@@ -42,7 +42,7 @@
         {
           "properties": {
             "properties": {
-              "$ref": "#/definitions/require_any"
+              "$ref": "#/definitions/require_any_or_bands"
             }
           }
         },
@@ -78,7 +78,7 @@
         {
           "properties": {
             "summaries": {
-              "$ref": "#/definitions/require_any"
+              "$ref": "#/definitions/require_any_or_bands"
             }
           }
         }
@@ -86,21 +86,24 @@
     }
   ],
   "definitions": {
-    "require_any": {
+    "require_any_or_bands": {
       "anyOf": [
-        {"required": ["raster:data_type"]},
-        {"required": ["raster:unit"]},
-        {"required": ["raster:bits_per_sample"]},
-        {"required": ["raster:sampling"]},
-        {"required": ["raster:nodata"]},
-        {"required": ["raster:scale"]},
-        {"required": ["raster:offset"]},
-        {"required": ["raster:spatial_resolution"]},
-        {"required": ["raster:statistics"]},
-        {"required": ["raster:histogram"]},
+        {
+          "$ref": "#/definitions/require_any"
+        },
         {
           "$ref": "#/definitions/require_in_bands"
         }
+      ]
+    },
+    "require_any": {
+      "anyOf": [
+        {"required": ["raster:bits_per_sample"]},
+        {"required": ["raster:sampling"]},
+        {"required": ["raster:scale"]},
+        {"required": ["raster:offset"]},
+        {"required": ["raster:spatial_resolution"]},
+        {"required": ["raster:histogram"]}
       ]
     },
     "require_in_bands": {
@@ -109,12 +112,9 @@
       ],
       "properties": {
         "bands": {
-          "not": {
-            "additionalProperties": {
-              "not": {
-                "$ref": "#/definitions/require_any"
-              }
-            }
+          "type": "array",
+          "contains": {
+            "$ref": "#/definitions/require_any"
           }
         }
       }
@@ -128,7 +128,7 @@
           "not": {
             "additionalProperties": {
               "not": {
-                "$ref": "#/definitions/require_any"
+                "$ref": "#/definitions/require_any_or_bands"
               }
             }
           }
@@ -144,7 +144,7 @@
           "not": {
             "additionalProperties": {
               "not": {
-                "$ref": "#/definitions/require_any"
+                "$ref": "#/definitions/require_any_or_bands"
               }
             }
           }
@@ -160,32 +160,6 @@
             "$ref": "#/definitions/fields"
           }
         },
-        "raster:data_type": {
-          "title": "Data type of the band",
-          "type": "string",
-          "enum": [
-            "int8",
-            "int16",
-            "int32",
-            "int64",
-            "uint8",
-            "uint16",
-            "uint32",
-            "uint64",
-            "float16",
-            "float32",
-            "float64",
-            "cint16",
-            "cint32",
-            "cfloat32",
-            "cfloat64",
-            "other"
-          ]
-        },
-        "raster:unit": {
-          "title": "Unit denomination of the pixel value",
-          "type": "string"
-        },
         "raster:bits_per_sample": {
           "title": "The actual number of bits used for this band",
           "type": "integer"
@@ -196,22 +170,6 @@
           "enum": [
             "area",
             "point"
-          ]
-        },
-        "raster:nodata": {
-          "title": "No data pixel value",
-          "oneOf": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "string",
-              "enum": [
-                "nan",
-                "inf",
-                "-inf"
-              ]
-            }
           ]
         },
         "raster:scale": {
@@ -225,34 +183,6 @@
         "raster:spatial_resolution": {
           "title": "Average spatial resolution (in meters) of the pixels in the band",
           "type": "number"
-        },
-        "raster:statistics": {
-          "title": "Statistics",
-          "type": "object",
-          "minProperties": 1,
-          "additionalProperties": false,
-          "properties": {
-            "mean": {
-              "title": "Mean value of all the pixels in the band",
-              "type": "number"
-            },
-            "minimum": {
-              "title": "Minimum value of all the pixels in the band",
-              "type": "number"
-            },
-            "maximum": {
-              "title": "Maximum value of all the pixels in the band",
-              "type": "number"
-            },
-            "stddev": {
-              "title": "Standard deviation value of all the pixels in the band",
-              "type": "number"
-            },
-            "valid_percent": {
-              "title": "Percentage of valid (not nodata) pixel",
-              "type": "number"
-            }
-          }
         },
         "raster:histogram": {
           "title": "Histogram",


### PR DESCRIPTION
See #42 

This updates the raster extension to use the new `bands` field in STAC 1.1 rather than `raster:bands`.